### PR TITLE
Removing the compute step from the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,14 @@ jobs:
         uses: utrustdev/action-deploy-ecs
         with:
           task-definition: ${{ steps.task_def.outputs.file }}
-          service: <service>
-          environment: <environment>
+          service: <ECS service>
+          cluster: <ECS cluster>
+          aws_account: <AWS Account ID to deploy to>
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_role: <role-to-assume-in-the-deployment-account>
           aws_region: eu-central-1
           wait-for-service-stability: false # default to false
-          force-new-deployment: true # will default to false
-          role-duration-seconds: 1800 # default to 3600
+          force-new-deployment: true        # will default to false
+          role-duration-seconds: 1800       # default to 3600
 ```

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   aws_role:
     description: "AWS role to use"
     required: true
+  aws_account:
+    description: "AWS account to deploy to"
+    required: true
   aws_region:
     description: "AWS region to use"
     required: true
@@ -40,35 +43,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Compute aws_account cluster based on environment
-      id: names
-      shell: bash
-      run: |
-        case "${{ inputs.environment }}" in
-          development)
-            cluster="dev-webservices"
-            aws_account="312759045859"
-            ;;
-          staging)
-            cluster="staging-webservices"
-            aws_account="103467854083"
-            ;;
-          sandbox)
-            cluster="sandbox-webservices"
-            aws_account="377785130582"
-            ;;
-          production)
-            cluster="production-webservices"
-            aws_account="950754345196"
-            ;;
-          dr)
-            cluster="dr-webservices"
-            aws_account="950754345196"
-            ;;
-        esac
-        echo "cluster=${cluster}" >> $GITHUB_OUTPUT
-        echo "aws_account=${aws_account}" >> "$GITHUB_OUTPUT"
-
     - name: Configure AWS credentials
       id: aws
       uses: aws-actions/configure-aws-credentials@v4.1.0
@@ -76,7 +50,7 @@ runs:
         aws-access-key-id: ${{ inputs.aws_access_key_id }}
         aws-secret-access-key: ${{ inputs.aws_secret_access_key }}
         aws-region: ${{ inputs.aws_region }}
-        role-to-assume: "arn:aws:iam::${{ steps.names.outputs.aws_account  }}:role/${{ inputs.aws_role }}"
+        role-to-assume: "arn:aws:iam::${{ inputs.aws_account  }}:role/${{ inputs.aws_role }}"
         role-skip-session-tagging	: true
         role-duration-seconds: "${{ inputs.role-duration-seconds }}"
 
@@ -85,6 +59,6 @@ runs:
       with:
         task-definition: ${{ inputs.task-definition }}
         service: ${{ inputs.service }}
-        cluster: "${{ steps.names.outputs.cluster }}"
+        cluster: "${{ inputs.cluster }}"
         wait-for-service-stability: ${{ inputs.wait-for-service-stability }}
         force-new-deployment: ${{ inputs.force-new-deployment }}

--- a/action.yml
+++ b/action.yml
@@ -8,8 +8,11 @@ inputs:
   service:
     description: "Service to deploy"
     required: true
-  environment:
-    description: "Environment to deploy to"
+  cluster:
+    description: "Cluster to deploy to"
+    required: true
+  aws_account:
+    description: "AWS account to deploy to"
     required: true
   aws_access_key_id:
     required: true
@@ -19,9 +22,6 @@ inputs:
     description: AWS secret key
   aws_role:
     description: "AWS role to use"
-    required: true
-  aws_account:
-    description: "AWS account to deploy to"
     required: true
   aws_region:
     description: "AWS region to use"


### PR DESCRIPTION
Some of our service names are not standard (platform service has different names across the environments) so it's best to remove the compute function out of the action and run it in the main deploy action like it was before.